### PR TITLE
Update notify.py

### DIFF
--- a/notify.py
+++ b/notify.py
@@ -138,7 +138,7 @@ for key, value in result.items():
 
 # Send result to zabbix
 logging.info( "sending metrics to '{0}': '{1}'".format(conf['zabbix_server'], metrics) )
-send_to_zabbix(metrics, conf['zabbix_server'], 10051, 20)
+send_to_zabbix(metrics, conf['zabbix_server'], 10051)
 
 # Send emails (if requested)
 if (args.recipients and


### PR DESCRIPTION
According https://github.com/pistolero/zbxsend syntax, the function is not wearing a zbxsend third parameter after the port. In my case, I had to remove the "20" at the end of the line No. 141 to work with Zabbix sender.
