### PR TITLE
Update notify_operator.py

### DIFF
--- a/notify_operator.py
+++ b/notify_operator.py
@@ -62,7 +62,7 @@ msg = sys.stdin.read()
 
 metrics = [ Metric(conf['hostname'], "{0}.custommessage".format(conf['type']), msg) ]
 logging.info( "sending custom message to '{0}': '{1}'".format(conf['zabbix_server'], metrics) )
-send_to_zabbix(metrics, conf['zabbix_server'], 10051, 20)
+send_to_zabbix(metrics, conf['zabbix_server'], 10051)
 
 if args.recipients:
     sendmail(msg, args.recipients)


### PR DESCRIPTION
According https://github.com/pistolero/zbxsend syntax, the function is not wearing a zbxsend third parameter after the port. In my case, I had to remove the "20" at the end of the line No. 141 to work with Zabbix sender.
